### PR TITLE
Unlock dustjs-linkedin peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "loader-utils": "0.2.11"
   },
   "peerDependencies": {
-    "dustjs-linkedin": "2.7.2"
+    "dustjs-linkedin": "~2.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Can we unlock dustjs-linkedin peer dependency ? The current version of dustjs-linkedin is 2.7.5. I propose to set dustjs-linkedin to tilde range.