### PR TITLE
Upgrade loader-utils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "loader-utils": "0.2.11"
+    "loader-utils": "0.2.16"
   },
   "peerDependencies": {
     "dustjs-linkedin": "~2.7"


### PR DESCRIPTION
Starting with webpack 2, it is also possible to pass an object reference from the webpack.config.js to the loader. loader-utils in version 0.2.11 throws error if this.query is not a string. This causes that the loader is not compatible with Webpack 2. See also discussion: https://github.com/webpack/loader-utils/issues/56. parseQuery is deprecated and will be replaced by getOptions at some point.